### PR TITLE
Updated django-supervisor to work with Python 3.13

### DIFF
--- a/djsupervisor/config.py
+++ b/djsupervisor/config.py
@@ -60,13 +60,13 @@ def get_merged_config(**options):
     cfg = RawConfigParser()
     #  Start from the default configuration options.
     data = render_config(DEFAULT_CONFIG,ctx)
-    cfg.readfp(StringIO(data))
+    cfg.read_file(StringIO(data))
     #  Add in the project-specific config file.
     with open(config_file,"r") as f:
         data = render_config(f.read(),ctx)
-    cfg.readfp(StringIO(data))
+    cfg.read_file(StringIO(data))
     #  Add in the options specified on the command-line.
-    cfg.readfp(StringIO(get_config_from_options(**options)))
+    cfg.read_file(StringIO(get_config_from_options(**options)))
     #  Add options from [program:__defaults__] to each program section
     #  if it happens to be missing that option.
     PROG_DEFAULTS = "program:__defaults__"

--- a/djsupervisor/management/commands/supervisor.py
+++ b/djsupervisor/management/commands/supervisor.py
@@ -292,7 +292,7 @@ class Command(BaseCommand):
         arguments, so we need to read it out of the merged config.
         """
         cfg = RawConfigParser()
-        cfg.readfp(cfg_file)
+        cfg.read_file(cfg_file)
         reload_progs = []
         for section in cfg.sections():
             if section.startswith("program:"):


### PR DESCRIPTION
Replaced `ConfigParser.readfp` (deprecated in Python 3.12) with `ConfigParser.read_file` to work with Python 3.13.

Related: sio2project/oioioi#582